### PR TITLE
Default to non-narrow clusters, warn if narrow

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -157,9 +157,14 @@ class SelectCoresForm(PrevDoneForm):
         self.drives_cores_field.set_value(str(PA.selected_cores.drives))
 
         self.name_field.set_value(PA.clustername)
-        if PA.datadrives is None or (PA.datadrives + PA.paritydrives) > len(PA.selected_hosts):
-            PA.datadrives = len(PA.selected_hosts) - 2
-            PA.paritydrives = 2
+        if PA.datadrives is None \
+                or (PA.datadrives + PA.paritydrives) > len(PA.selected_hosts):
+            if len(PA.selected_hosts) <= 18:
+                PA.datadrives = max(len(PA.selected_hosts) - 3, 3)
+                PA.paritydrives = 2
+            else:
+                PA.datadrives = 16
+                PA.paritydrives = 2
 
         if PA.datadrives > 16:
             PA.datadrives = 16

--- a/widgets.py
+++ b/widgets.py
@@ -231,6 +231,14 @@ class DataParityBase(CoresWidgetBase):
             return f"The most data drives for a cluster of {self.clustersize} hosts is {self.clustersize - 2}"
         elif self.intval + PA.paritydrives > self.clustersize:
             PA.paritydrives = 2
+
+        if self.intval + PA.paritydrives == self.clustersize \
+                and self.clustersize > 5:
+            wekatui.notify_wait(f"Stripe width" \
+                    + f" ({self.intval}+{PA.paritydrives}) matches cluster "
+                    + "size, forming a narrow cluster. Using a stripe width "
+                    + f"of {self.intval - 1}+{PA.paritydrives} is strongly "
+                    + "recommended instead.")
         return self._check_value()
 
     def _check_value(self):


### PR DESCRIPTION
The exception is a 5-node cluster, where a narrow cluster is impossible to avoid.